### PR TITLE
Closes #19

### DIFF
--- a/RconSharp/RconSharp.Tests/RconClientTests.cs
+++ b/RconSharp/RconSharp.Tests/RconClientTests.cs
@@ -28,15 +28,15 @@ namespace RconSharp.Tests
             channel.CancelNextReponse();
             var rconClient = RconClient.Create(channel);
             await rconClient.ConnectAsync();
-            var isConnectionClosed = false;
+            var tcs = new TaskCompletionSource<bool>();
             rconClient.ConnectionClosed += () =>
             {
-                isConnectionClosed = true;
+                tcs.SetResult(true);
             };
 
             // Act Assert
             await Assert.ThrowsAsync<TaskCanceledException>(() => rconClient.ExecuteCommandAsync("test echo"));
-            Assert.True(isConnectionClosed);
+            Assert.True(await tcs.Task);
         }
 
         [Theory]


### PR DESCRIPTION
Replace boolean check with an awaitable Task
to avoid a race condition that occasionally makes the disconnection test to fail during automated build