### PR TITLE
CancellationToken support

### DIFF
--- a/RconSharp/RconSharp/IChannel.cs
+++ b/RconSharp/RconSharp/IChannel.cs
@@ -25,6 +25,7 @@ SOFTWARE.
 
 using System;
 using System.IO;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace RconSharp
@@ -38,7 +39,7 @@ namespace RconSharp
 		/// Connect the socket to the remote endpoint
 		/// </summary>
 		/// <returns>True if the connection was successfully; False if the connection is already estabilished</returns>
-		Task ConnectAsync();
+		Task ConnectAsync(CancellationToken cancellationToken);
 		/// <summary>
 		/// Disconnect the channel
 		/// </summary>
@@ -48,13 +49,13 @@ namespace RconSharp
 		/// </summary>
 		/// <param name="payload">Payload to be written</param>
 		/// <returns>Operation's Task</returns>
-		Task SendAsync(ReadOnlyMemory<byte> payload);
+		Task SendAsync(ReadOnlyMemory<byte> payload, CancellationToken cancellationToken);
 		/// <summary>
 		/// Read data from the channel
 		/// </summary>
 		/// <param name="responseBuffer">Buffer to be filled</param>
 		/// <returns>Number of bytes read</returns>
-		Task<int> ReceiveAsync(Memory<byte> responseBuffer);
+		Task<int> ReceiveAsync(Memory<byte> responseBuffer, CancellationToken cancellationToken);
 		/// <summary>
 		/// Get whether the channel is connected or not
 		/// </summary>

--- a/RconSharp/RconSharp/SocketChannel.cs
+++ b/RconSharp/RconSharp/SocketChannel.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Net.Sockets;
+using System.Threading;
 using System.Threading.Tasks;
 
 /*
@@ -67,7 +68,7 @@ namespace RconSharp
 		/// Connect the socket to the remote endpoint
 		/// </summary>
 		/// <returns>True if the connection was successfully; False if the connection is already estabilished</returns>
-		public async Task ConnectAsync()
+		public async Task ConnectAsync(CancellationToken cancellationToken)
 		{
 			if (socket != null)
 				return;
@@ -77,7 +78,7 @@ namespace RconSharp
             socket.SendTimeout = 5000;
             socket.NoDelay = true;
 
-			await socket.ConnectAsync(host, port).ConfigureAwait(false);
+			await socket.ConnectAsync(host, port, cancellationToken).ConfigureAwait(false);
 		}
 
 		/// <summary>
@@ -85,9 +86,9 @@ namespace RconSharp
 		/// </summary>
 		/// <param name="payload">Payload to be written</param>
 		/// <returns>Operation's Task</returns>
-		public async Task SendAsync(ReadOnlyMemory<byte> payload)
+		public async Task SendAsync(ReadOnlyMemory<byte> payload, CancellationToken cancellationToken)
 		{
-			await socket.SendAsync(payload, SocketFlags.None).ConfigureAwait(false);
+			await socket.SendAsync(payload, SocketFlags.None, cancellationToken).ConfigureAwait(false);
 		}
 
 		/// <summary>
@@ -95,9 +96,9 @@ namespace RconSharp
 		/// </summary>
 		/// <param name="responseBuffer">Buffer to be filled</param>
 		/// <returns>Number of bytes read</returns>
-		public async Task<int> ReceiveAsync(Memory<byte> responseBuffer)
+		public async Task<int> ReceiveAsync(Memory<byte> responseBuffer, CancellationToken cancellationToken)
 		{
-			return await socket.ReceiveAsync(responseBuffer, SocketFlags.None).ConfigureAwait(false);
+			return await socket.ReceiveAsync(responseBuffer, SocketFlags.None, cancellationToken).ConfigureAwait(false);
 		}
 
 		/// <summary>


### PR DESCRIPTION
I've added support for passing CancellationTokens into RconSharp.

<details>
<summary>Rationale</summary>
The main reason why I decided to do this, is because my Minecraft server shuts down automatically when nobody is online for 20 minutes, and starts automatically when some tries to join. The web app I wrote for managing the server doesn't play nice with this system, as the RconClient is used as a singleton within the app. If I try to execute a command after the server has shut down, even if the server has already started again, a reply never arrives because the server does not have an open connection with my app, even though RconSharp thinks it has an open connection with the server.
</details>

So I did this so you can specify a timeout for ExecuteCommandAsync and ConnectAsync. **However**, there is a weird problem with the compiler. If I try to compile this right now, there is an error in SocketChannel.cs, line 81, where the compiler can't see the extension method `ConnectAsync(string, int, CancellationToken)` even though it clearly exists within the same class as the ConnectAsync that was previously used. After some investigation, I found out that there are two distinct CancellationTokens: one defined in System.Runtime.dll, and the other in System.Private.CoreLib.dll. The first one is used by RconSharp, and the second one is used by SocketChannelExtensions. I'm not sure why this is a problem for ConnectAsync, because `SendAsync` and `ReceiveAsync` do not have this problem.

Directly calling the extension method as `System.Net.Sockets.SocketChannelExtensions.ConnectAsync(socket, host, port, cancellationToken)` does not work either.

I was wondering if you had any idea how to fix this.

(These changes were not tested because of this issue.)